### PR TITLE
#15: any other branches than "master' don't increment patch level

### DIFF
--- a/gitversion/GitVersion.yaml
+++ b/gitversion/GitVersion.yaml
@@ -29,7 +29,7 @@ branches:
   feature:
     mode: ContinuousDelivery
     tag: useBranchName
-    increment: Patch
+    increment: None
     prevent-increment-of-merged-branch-version: false
     track-merge-target: false
     regex: ^((?!master).)*$


### PR DESCRIPTION
This fixes the bug mentioned in #15, and https://github.com/elbb/bb-gitversion/pull/14#issuecomment-635120178